### PR TITLE
Don't send model name to Azure OpenAI since it may be rejected

### DIFF
--- a/OpenAI.WinRT.nuspec
+++ b/OpenAI.WinRT.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>OpenAI.WinRT</id>
-    <version>0.0.10</version>
+    <version>0.0.11</version>
     <title>OpenAI.WinRT</title>
     <authors>Alexander Sklar</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>


### PR DESCRIPTION
the prior fix didn't really allow for 3.5-turbo models on AOAI